### PR TITLE
Allow client_secret to be ommitted from requests if configured in the cl...

### DIFF
--- a/access.go
+++ b/access.go
@@ -458,7 +458,7 @@ func getClient(auth *BasicAuth, storage Storage, w *Response) Client {
 		w.SetError(E_UNAUTHORIZED_CLIENT, "")
 		return nil
 	}
-	if client.GetSecret() != auth.Password {
+	if client.GetRequiresSecret() && client.GetSecret() != auth.Password {
 		w.SetError(E_UNAUTHORIZED_CLIENT, "")
 		return nil
 	}

--- a/client.go
+++ b/client.go
@@ -11,6 +11,9 @@ type Client interface {
 	// Base client uri
 	GetRedirectUri() string
 
+    // Allow client secret to be ignored for mobile and desktop clients
+    GetRequiresSecret() bool
+
 	// Data to be passed to storage. Not used by the library.
 	GetUserData() interface{}
 }
@@ -20,6 +23,7 @@ type DefaultClient struct {
 	Id          string
 	Secret      string
 	RedirectUri string
+    RequiresSecret bool
 	UserData    interface{}
 }
 
@@ -35,6 +39,10 @@ func (d *DefaultClient) GetRedirectUri() string {
 	return d.RedirectUri
 }
 
+func (d *DefaultClient) GetRequiresSecret() bool {
+    return d.RequiresSecret
+}
+
 func (d *DefaultClient) GetUserData() interface{} {
 	return d.UserData
 }
@@ -43,5 +51,6 @@ func (d *DefaultClient) CopyFrom(client Client) {
 	d.Id = client.GetId()
 	d.Secret = client.GetSecret()
 	d.RedirectUri = client.GetRedirectUri()
+    d.RequiresSecret = client.GetRequiresSecret()
 	d.UserData = client.GetUserData()
 }

--- a/client.go
+++ b/client.go
@@ -11,8 +11,8 @@ type Client interface {
 	// Base client uri
 	GetRedirectUri() string
 
-    // Allow client secret to be ignored for mobile and desktop clients
-    GetRequiresSecret() bool
+	// Allow client secret to be ignored for mobile and desktop clients
+	GetRequiresSecret() bool
 
 	// Data to be passed to storage. Not used by the library.
 	GetUserData() interface{}
@@ -20,11 +20,11 @@ type Client interface {
 
 // DefaultClient stores all data in struct variables
 type DefaultClient struct {
-	Id          string
-	Secret      string
-	RedirectUri string
-    RequiresSecret bool
-	UserData    interface{}
+	Id             string
+	Secret         string
+	RedirectUri    string
+	RequiresSecret bool
+	UserData       interface{}
 }
 
 func (d *DefaultClient) GetId() string {
@@ -40,7 +40,7 @@ func (d *DefaultClient) GetRedirectUri() string {
 }
 
 func (d *DefaultClient) GetRequiresSecret() bool {
-    return d.RequiresSecret
+	return d.RequiresSecret
 }
 
 func (d *DefaultClient) GetUserData() interface{} {
@@ -51,6 +51,6 @@ func (d *DefaultClient) CopyFrom(client Client) {
 	d.Id = client.GetId()
 	d.Secret = client.GetSecret()
 	d.RedirectUri = client.GetRedirectUri()
-    d.RequiresSecret = client.GetRequiresSecret()
+	d.RequiresSecret = client.GetRequiresSecret()
 	d.UserData = client.GetUserData()
 }

--- a/example/teststorage.go
+++ b/example/teststorage.go
@@ -25,6 +25,7 @@ func NewTestStorage() *TestStorage {
 		Id:          "1234",
 		Secret:      "aabbccdd",
 		RedirectUri: "http://localhost:14000/appauth",
+        RequiresSecret: true,
 	}
 
 	return r

--- a/util.go
+++ b/util.go
@@ -51,7 +51,14 @@ func getClientAuth(w *Response, r *http.Request, allowQueryParams bool) *BasicAu
 			if auth.Username != "" {
 				return auth
 			}
-		}
+		} else if _, hasClient := r.Form["client_id"]; hasClient {
+            auth := &BasicAuth{
+                Username: r.Form.Get("client_id"),
+            }
+            if auth.Username != "" {
+                return auth
+            }
+        }
 	}
 
 	auth, err := CheckBasicAuth(r)

--- a/util.go
+++ b/util.go
@@ -52,13 +52,13 @@ func getClientAuth(w *Response, r *http.Request, allowQueryParams bool) *BasicAu
 				return auth
 			}
 		} else if _, hasClient := r.Form["client_id"]; hasClient {
-            auth := &BasicAuth{
-                Username: r.Form.Get("client_id"),
-            }
-            if auth.Username != "" {
-                return auth
-            }
-        }
+			auth := &BasicAuth{
+				Username: r.Form.Get("client_id"),
+			}
+			if auth.Username != "" {
+				return auth
+			}
+		}
 	}
 
 	auth, err := CheckBasicAuth(r)

--- a/util_test.go
+++ b/util_test.go
@@ -63,14 +63,14 @@ func TestGetClientAuth(t *testing.T) {
 		{headerNoAuth, urlWithSecret, false, false},
 		{headerNoAuth, urlWithEmptySecret, true, true},
 		{headerNoAuth, urlWithEmptySecret, false, false},
-		{headerNoAuth, urlNoSecret, true, false},
+		{headerNoAuth, urlNoSecret, true, true},
 		{headerNoAuth, urlNoSecret, false, false},
 
 		{headerBadAuth, urlWithSecret, true, true},
 		{headerBadAuth, urlWithSecret, false, false},
 		{headerBadAuth, urlWithEmptySecret, true, true},
 		{headerBadAuth, urlWithEmptySecret, false, false},
-		{headerBadAuth, urlNoSecret, true, false},
+		{headerBadAuth, urlNoSecret, true, true},
 		{headerBadAuth, urlNoSecret, false, false},
 
 		{headerOKAuth, urlWithSecret, true, true},


### PR DESCRIPTION
...ient settings

Sorry - I stuffed up the pull request I had created for this change, so here is just the client change, without my merge commits. Below is the original pull request comment.

RangelReale - any comment on these changes?




Thanks for your work on the library so far. This is just a small change I need to ensure that I can keep the client secret out of my mobile application. So for that client only I will be needing to set the RequiresSecret configuration to false. (FWIW, the mobile app is going to be using password authentication only). Other clients will continue to work as usual.

I suppose you're already across why a client would want to keep the secret private and the mentions of this in the spec. If not then most of what I know about the reasoning behind keeping the client secret out of mobile and desktop applications is summarised well here:

http://stackoverflow.com/questions/19615372/client-secret-in-oauth-2-0
and here:
http://salesforce.stackexchange.com/questions/14009/whats-the-benefit-of-the-client-secret-in-oauth2

"Web apps use client secrets because they represent huge attack vectors. Let us say that someone poisons a DNS entry and sets up a rogue app "lookalike", the juxtapose might not be noticed for months, with this intermediary sucking up tons of data. Client secrets are supposed to mitigate this attack vector. For single user clients, compromise has to come one device at a time, which is horribly inefficient in comparison. While true that they are marginally less secure, they're still required to use TLS (avoids man-in-the-middle) and request-body posting (avoids logs)."