### PR TITLE
Proposed changes for GAE compatibility

### DIFF
--- a/access_test.go
+++ b/access_test.go
@@ -11,7 +11,7 @@ func TestAccessAuthorizationCode(t *testing.T) {
 	sconfig.AllowedAccessTypes = AllowedAccessType{AUTHORIZATION_CODE}
 	server := NewServer(sconfig, NewTestingStorage())
 	server.AccessTokenGen = &TestingAccessTokenGen{}
-	resp := server.NewResponse()
+	resp := server.NewResponse(nil)
 
 	req, err := http.NewRequest("POST", "http://localhost:14000/appauth", nil)
 	if err != nil {
@@ -58,7 +58,7 @@ func TestAccessRefreshToken(t *testing.T) {
 	sconfig.AllowedAccessTypes = AllowedAccessType{REFRESH_TOKEN}
 	server := NewServer(sconfig, NewTestingStorage())
 	server.AccessTokenGen = &TestingAccessTokenGen{}
-	resp := server.NewResponse()
+	resp := server.NewResponse(nil)
 
 	req, err := http.NewRequest("POST", "http://localhost:14000/appauth", nil)
 	if err != nil {
@@ -105,7 +105,7 @@ func TestAccessPassword(t *testing.T) {
 	sconfig.AllowedAccessTypes = AllowedAccessType{PASSWORD}
 	server := NewServer(sconfig, NewTestingStorage())
 	server.AccessTokenGen = &TestingAccessTokenGen{}
-	resp := server.NewResponse()
+	resp := server.NewResponse(nil)
 
 	req, err := http.NewRequest("POST", "http://localhost:14000/appauth", nil)
 	if err != nil {
@@ -153,7 +153,7 @@ func TestAccessClientCredentials(t *testing.T) {
 	sconfig.AllowedAccessTypes = AllowedAccessType{CLIENT_CREDENTIALS}
 	server := NewServer(sconfig, NewTestingStorage())
 	server.AccessTokenGen = &TestingAccessTokenGen{}
-	resp := server.NewResponse()
+	resp := server.NewResponse(nil)
 
 	req, err := http.NewRequest("POST", "http://localhost:14000/appauth", nil)
 	if err != nil {

--- a/authorize_test.go
+++ b/authorize_test.go
@@ -11,7 +11,7 @@ func TestAuthorizeCode(t *testing.T) {
 	sconfig.AllowedAuthorizeTypes = AllowedAuthorizeType{CODE}
 	server := NewServer(sconfig, NewTestingStorage())
 	server.AuthorizeTokenGen = &TestingAuthorizeTokenGen{}
-	resp := server.NewResponse()
+	resp := server.NewResponse(nil)
 
 	req, err := http.NewRequest("GET", "http://localhost:14000/appauth", nil)
 	if err != nil {
@@ -52,7 +52,7 @@ func TestAuthorizeToken(t *testing.T) {
 	server := NewServer(sconfig, NewTestingStorage())
 	server.AuthorizeTokenGen = &TestingAuthorizeTokenGen{}
 	server.AccessTokenGen = &TestingAccessTokenGen{}
-	resp := server.NewResponse()
+	resp := server.NewResponse(nil)
 
 	req, err := http.NewRequest("GET", "http://localhost:14000/appauth", nil)
 	if err != nil {

--- a/info_test.go
+++ b/info_test.go
@@ -9,7 +9,7 @@ import (
 func TestInfo(t *testing.T) {
 	sconfig := NewServerConfig()
 	server := NewServer(sconfig, NewTestingStorage())
-	resp := server.NewResponse()
+	resp := server.NewResponse(nil)
 
 	req, err := http.NewRequest("GET", "http://localhost:14000/appauth", nil)
 	if err != nil {

--- a/response.go
+++ b/response.go
@@ -35,7 +35,7 @@ type Response struct {
 	Storage Storage
 }
 
-func NewResponse(storage Storage) *Response {
+func NewResponse(storage Storage, httpRequest *http.Request) *Response {
 	r := &Response{
 		Type:            DATA,
 		StatusCode:      200,
@@ -43,7 +43,7 @@ func NewResponse(storage Storage) *Response {
 		Output:          make(ResponseData),
 		Headers:         make(http.Header),
 		IsError:         false,
-		Storage:         storage.Clone(),
+		Storage:         storage.Clone(httpRequest),
 	}
 	r.Headers.Add("Cache-Control", "no-store")
 	return r

--- a/response.go
+++ b/response.go
@@ -35,7 +35,7 @@ type Response struct {
 	Storage Storage
 }
 
-func NewResponse(storage Storage, httpRequest *http.Request) *Response {
+func NewResponse(storage Storage, sess interface{}) *Response {
 	r := &Response{
 		Type:            DATA,
 		StatusCode:      200,
@@ -43,7 +43,7 @@ func NewResponse(storage Storage, httpRequest *http.Request) *Response {
 		Output:          make(ResponseData),
 		Headers:         make(http.Header),
 		IsError:         false,
-		Storage:         storage.Clone(httpRequest),
+		Storage:         storage.Clone(sess),
 	}
 	r.Headers.Add("Cache-Control", "no-store")
 	return r

--- a/response_json_test.go
+++ b/response_json_test.go
@@ -15,7 +15,7 @@ func TestResponseJSON(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	r := NewResponse(NewTestingStorage())
+	r := NewResponse(NewTestingStorage(), nil)
 	r.Output["access_token"] = "1234"
 	r.Output["token_type"] = "5678"
 
@@ -57,7 +57,7 @@ func TestErrorResponseJSON(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	r := NewResponse(NewTestingStorage())
+	r := NewResponse(NewTestingStorage(), nil)
 	r.ErrorStatusCode = 500
 	r.SetError(E_INVALID_REQUEST, "")
 
@@ -95,7 +95,7 @@ func TestRedirectResponseJSON(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	r := NewResponse(NewTestingStorage())
+	r := NewResponse(NewTestingStorage(), nil)
 	r.SetRedirect("http://localhost:14000")
 
 	err = OutputJSON(r, w, req)

--- a/server.go
+++ b/server.go
@@ -23,7 +23,7 @@ func NewServer(config *ServerConfig, storage Storage) *Server {
 }
 
 // NewResponse creates a new response for the server
-func (s *Server) NewResponse(httpRequest *http.Request) *Response {
+func (s *Server) NewResponse(sess interface{}) *Response {
 	r := &Response{
 		Type:            DATA,
 		StatusCode:      200,
@@ -31,7 +31,7 @@ func (s *Server) NewResponse(httpRequest *http.Request) *Response {
 		Output:          make(ResponseData),
 		Headers:         make(http.Header),
 		IsError:         false,
-		Storage:         s.Storage.Clone(httpRequest),
+		Storage:         s.Storage.Clone(sess),
 	}
 	r.Headers.Add("Cache-Control", "no-store")
 	r.ErrorStatusCode = s.Config.ErrorStatusCode

--- a/server.go
+++ b/server.go
@@ -23,7 +23,7 @@ func NewServer(config *ServerConfig, storage Storage) *Server {
 }
 
 // NewResponse creates a new response for the server
-func (s *Server) NewResponse() *Response {
+func (s *Server) NewResponse(httpRequest *http.Request) *Response {
 	r := &Response{
 		Type:            DATA,
 		StatusCode:      200,
@@ -31,7 +31,7 @@ func (s *Server) NewResponse() *Response {
 		Output:          make(ResponseData),
 		Headers:         make(http.Header),
 		IsError:         false,
-		Storage:         s.Storage.Clone(),
+		Storage:         s.Storage.Clone(httpRequest),
 	}
 	r.Headers.Add("Cache-Control", "no-store")
 	r.ErrorStatusCode = s.Config.ErrorStatusCode

--- a/storage.go
+++ b/storage.go
@@ -1,8 +1,6 @@
 package osin
 
-import (
-	"net/http"
-)
+import ()
 
 // Storage interface
 type Storage interface {
@@ -10,7 +8,7 @@ type Storage interface {
 	// to avoid concurrent access problems.
 	// This is to avoid cloning the connection at each method access.
 	// Can return itself if not a problem.
-	Clone(httpRequest *http.Request) Storage
+	Clone(sess interface{}) Storage
 
 	// Close the resources the Storate potentially holds (using Clone for example)
 	Close()

--- a/storage.go
+++ b/storage.go
@@ -1,6 +1,8 @@
 package osin
 
-import ()
+import (
+	"net/http"
+)
 
 // Storage interface
 type Storage interface {
@@ -8,7 +10,7 @@ type Storage interface {
 	// to avoid concurrent access problems.
 	// This is to avoid cloning the connection at each method access.
 	// Can return itself if not a problem.
-	Clone() Storage
+	Clone(httpRequest *http.Request) Storage
 
 	// Close the resources the Storate potentially holds (using Clone for example)
 	Close()

--- a/storage_test.go
+++ b/storage_test.go
@@ -2,7 +2,6 @@ package osin
 
 import (
 	"errors"
-	"net/http"
 	"strconv"
 	"time"
 )
@@ -59,7 +58,7 @@ func NewTestingStorage() *TestingStorage {
 	return r
 }
 
-func (s *TestingStorage) Clone(httpRequest *http.Request) Storage {
+func (s *TestingStorage) Clone(sess interface{}) Storage {
 	return s
 }
 

--- a/storage_test.go
+++ b/storage_test.go
@@ -2,6 +2,7 @@ package osin
 
 import (
 	"errors"
+	"net/http"
 	"strconv"
 	"time"
 )
@@ -58,7 +59,7 @@ func NewTestingStorage() *TestingStorage {
 	return r
 }
 
-func (s *TestingStorage) Clone() Storage {
+func (s *TestingStorage) Clone(httpRequest *http.Request) Storage {
 	return s
 }
 


### PR DESCRIPTION
To make osin compatible with Google App Engine, the http request
needed to be pass in to Storage. Therefore these breaking change.
- Change Storage.Clone() to require a *http.Request
  This breaks previous implementation of Storage interface
- Change NewResponse() and Server.NewResponse() to require a
  *http.Request. This breaks previous code uses these interfaces.
- Change NewResponse() and Server.NewResponse() to pass the
  *http.Request to Storage.Clone()

This pull request fixes #28.
