### PR TITLE
Remove token bloat

### DIFF
--- a/tokengen.go
+++ b/tokengen.go
@@ -1,18 +1,24 @@
 package osin
 
 import (
-	"code.google.com/p/go-uuid/uuid"
 	"encoding/base64"
+	"strings"
+
+	"code.google.com/p/go-uuid/uuid"
 )
 
 // AuthorizeTokenGenDefault is the default authorization token generator
 type AuthorizeTokenGenDefault struct {
 }
 
+func removePadding(token string) string {
+	return strings.TrimRight(token, "=")
+}
+
 // GenerateAuthorizeToken generates a base64-encoded UUID code
 func (a *AuthorizeTokenGenDefault) GenerateAuthorizeToken(data *AuthorizeData) (ret string, err error) {
-	token := uuid.New()
-	return base64.StdEncoding.EncodeToString([]byte(token)), nil
+	token := uuid.NewUUID()
+	return removePadding(base64.URLEncoding.EncodeToString([]byte(token))), nil
 }
 
 // AccessTokenGenDefault is the default authorization token generator
@@ -21,12 +27,12 @@ type AccessTokenGenDefault struct {
 
 // GenerateAccessToken generates base64-encoded UUID access and refresh tokens
 func (a *AccessTokenGenDefault) GenerateAccessToken(data *AccessData, generaterefresh bool) (accesstoken string, refreshtoken string, err error) {
-	accesstoken = uuid.New()
-	accesstoken = base64.StdEncoding.EncodeToString([]byte(accesstoken))
+	token := uuid.NewUUID()
+	accesstoken = removePadding(base64.URLEncoding.EncodeToString([]byte(token)))
 
 	if generaterefresh {
-		refreshtoken = uuid.New()
-		refreshtoken = base64.StdEncoding.EncodeToString([]byte(refreshtoken))
+		rtoken := uuid.NewUUID()
+		refreshtoken = removePadding(base64.URLEncoding.EncodeToString([]byte(rtoken)))
 	}
 	return
 }


### PR DESCRIPTION
Tokens were hex-encoded (as UUIDs) and then base64-encoded.  This creates bloat (as the there are only 128 bits of entropy being encoded in 384 bits).

(This also might create a false sense of security: the tokens "look" like 288-bit tokens, rather than 128-bit.)

Old token example:

```
NTM2ZDAyMDEtODc0Yi00NGE5LTg1MjUtZDcxOTcyYmE5OGRh
```

which decodes as:

```
536d0201-874b-44a9-8525-d71972ba98da
```

In the new system, this would be encoded as:

```
U20CAYdLRKmFJdcZcrqY2g
```

(We have also removed the `==` padding from the right.)