### PR TITLE
Inject current time for easier testing.

### DIFF
--- a/access.go
+++ b/access.go
@@ -86,7 +86,12 @@ type AccessData struct {
 
 // IsExpired returns true if access expired
 func (d *AccessData) IsExpired() bool {
-	return d.CreatedAt.Add(time.Duration(d.ExpiresIn) * time.Second).Before(time.Now())
+	return d.IsExpiredAt(time.Now())
+}
+
+// IsExpiredAt returns true if access expires at time 't'
+func (d *AccessData) IsExpiredAt(t time.Time) bool {
+	return d.ExpireAt().Before(t)
 }
 
 // ExpireAt returns the expiration date
@@ -407,7 +412,7 @@ func (s *Server) FinishAccessRequest(w *Response, r *http.Request, ar *AccessReq
 				AuthorizeData: ar.AuthorizeData,
 				AccessData:    ar.AccessData,
 				RedirectUri:   redirectUri,
-				CreatedAt:     time.Now(),
+				CreatedAt:     s.Now(),
 				ExpiresIn:     ar.Expiration,
 				UserData:      ar.UserData,
 				Scope:         ar.Scope,

--- a/access.go
+++ b/access.go
@@ -194,7 +194,7 @@ func (s *Server) handleAuthorizationCodeRequest(w *Response, r *http.Request) *A
 		w.SetError(E_UNAUTHORIZED_CLIENT, "")
 		return nil
 	}
-	if ret.AuthorizeData.IsExpired() {
+	if ret.AuthorizeData.IsExpiredAt(s.Now()) {
 		w.SetError(E_INVALID_GRANT, "")
 		return nil
 	}

--- a/authorize.go
+++ b/authorize.go
@@ -65,7 +65,12 @@ type AuthorizeData struct {
 
 // IsExpired is true if authorization expired
 func (d *AuthorizeData) IsExpired() bool {
-	return d.CreatedAt.Add(time.Duration(d.ExpiresIn) * time.Second).Before(time.Now())
+	return d.IsExpiredAt(time.Now())
+}
+
+// IsExpired is true if authorization expires at time 't'
+func (d *AuthorizeData) IsExpiredAt(t time.Time) bool {
+	return d.ExpireAt().Before(t)
 }
 
 // ExpireAt returns the expiration date
@@ -228,7 +233,7 @@ func (s *Server) FinishAuthorizeRequest(w *Response, r *http.Request, ar *Author
 			// generate authorization token
 			ret := &AuthorizeData{
 				Client:      ar.Client,
-				CreatedAt:   time.Now(),
+				CreatedAt:   s.Now(),
 				ExpiresIn:   ar.Expiration,
 				RedirectUri: ar.RedirectUri,
 				State:       ar.State,

--- a/info.go
+++ b/info.go
@@ -48,7 +48,7 @@ func (s *Server) HandleInfoRequest(w *Response, r *http.Request) *InfoRequest {
 		w.SetError(E_UNAUTHORIZED_CLIENT, "")
 		return nil
 	}
-	if ret.AccessData.IsExpired() {
+	if ret.AccessData.IsExpiredAt(s.Now()) {
 		w.SetError(E_INVALID_GRANT, "")
 		return nil
 	}

--- a/info.go
+++ b/info.go
@@ -67,7 +67,7 @@ func (s *Server) FinishInfoRequest(w *Response, r *http.Request, ir *InfoRequest
 	w.Output["client_id"] = ir.AccessData.Client.GetId()
 	w.Output["access_token"] = ir.AccessData.AccessToken
 	w.Output["token_type"] = s.Config.TokenType
-	w.Output["expires_in"] = ir.AccessData.CreatedAt.Add(time.Duration(ir.AccessData.ExpiresIn)*time.Second).Sub(time.Now()) / time.Second
+	w.Output["expires_in"] = ir.AccessData.CreatedAt.Add(time.Duration(ir.AccessData.ExpiresIn)*time.Second).Sub(s.Now()) / time.Second
 	if ir.AccessData.RefreshToken != "" {
 		w.Output["refresh_token"] = ir.AccessData.RefreshToken
 	}

--- a/server.go
+++ b/server.go
@@ -2,6 +2,7 @@ package osin
 
 import (
 	"net/http"
+	"time"
 )
 
 // Server is an OAuth2 implementation
@@ -10,6 +11,7 @@ type Server struct {
 	Storage           Storage
 	AuthorizeTokenGen AuthorizeTokenGen
 	AccessTokenGen    AccessTokenGen
+	Now               func() time.Time
 }
 
 // NewServer creates a new server instance
@@ -19,6 +21,7 @@ func NewServer(config *ServerConfig, storage Storage) *Server {
 		Storage:           storage,
 		AuthorizeTokenGen: &AuthorizeTokenGenDefault{},
 		AccessTokenGen:    &AccessTokenGenDefault{},
+		Now:               time.Now,
 	}
 }
 


### PR DESCRIPTION
Sometimes OAuth flow is a part of integration/functional tests, and its direct usage of `time.Now()` clashes with fake time in tests, so I added injectable time function to the server.

Patching time in `IsExpired()` by adding a function would probably be over the top, so I added `IsExpiredAt(time.Time)` variant instead.

The change is fully backwards compatible.