### PR TITLE
Checking if bearer is nil in info request

### DIFF
--- a/info.go
+++ b/info.go
@@ -16,6 +16,10 @@ type InfoRequest struct {
 func (s *Server) HandleInfoRequest(w *Response, r *http.Request) *InfoRequest {
 	r.ParseForm()
 	bearer := CheckBearerAuth(r)
+	if bearer == nil {
+		w.SetError(E_INVALID_REQUEST, "")
+		return nil
+	}
 
 	// generate info request
 	ret := &InfoRequest{


### PR DESCRIPTION
When the bearer token is not present in info request, the code panics due to nil pointer reference.