### PR TITLE
only set the Content-Type header when one hasn't already been set

### DIFF
--- a/response_json.go
+++ b/response_json.go
@@ -23,8 +23,10 @@ func OutputJSON(rs *Response, w http.ResponseWriter, r *http.Request) error {
 		w.Header().Add("Location", u)
 		w.WriteHeader(302)
 	} else {
-		// Output json
-		w.Header().Add("Content-Type", "application/json")
+		// set content type if the response doesn't already have one associated with it
+		if w.Header().Get("Content-Type") == "" {
+			w.Header().Set("Content-Type", "application/json")
+		}
 		w.WriteHeader(rs.StatusCode)
 
 		encoder := json.NewEncoder(w)


### PR DESCRIPTION
We're indicating errors in our API with the `Content-type: application/problem+json` Header. However, because the osin library currently always adds a `Content-Type: application/json` header we end up with multiple `Content-Type`s in our response. This change respects any `Content-Type` header currently present in the `Response` and only `Set`s it if it doesn't already exist in the `Response`