### PR TITLE
Added a check for extra scopes on a refresh token

### DIFF
--- a/access.go
+++ b/access.go
@@ -3,6 +3,7 @@ package osin
 import (
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -227,6 +228,30 @@ func (s *Server) handleAuthorizationCodeRequest(w *Response, r *http.Request) *A
 	return ret
 }
 
+func extraScopes(access_scopes, refresh_scopes string) bool {
+	access_scopes_list := strings.Split(access_scopes, ",")
+	refresh_scopes_list := strings.Split(refresh_scopes, ",")
+
+	access_map := make(map[string]int)
+
+	for _, scope := range access_scopes_list {
+		if scope == "" {
+			continue
+		}
+		access_map[scope] = 1
+	}
+
+	for _, scope := range refresh_scopes_list {
+		if scope == "" {
+			continue
+		}
+		if _, ok := access_map[scope]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Server) handleRefreshTokenRequest(w *Response, r *http.Request) *AccessRequest {
 	// get client authentication
 	auth := getClientAuth(w, r, s.Config.AllowClientSecretInParams)
@@ -289,6 +314,12 @@ func (s *Server) handleRefreshTokenRequest(w *Response, r *http.Request) *Access
 	ret.UserData = ret.AccessData.UserData
 	if ret.Scope == "" {
 		ret.Scope = ret.AccessData.Scope
+	}
+
+	if extraScopes(ret.AccessData.Scope, ret.Scope) {
+		w.SetError(E_ACCESS_DENIED, "")
+		w.InternalError = errors.New("the requested scope must not include any scope not originally granted by the resource owner")
+		return nil
 	}
 
 	return ret

--- a/access_test.go
+++ b/access_test.go
@@ -211,4 +211,8 @@ func TestExtraScopes(t *testing.T) {
 		t.Fatalf("extraScopes returned false with extra scopes")
 	}
 
+	if extraScopes("", "a") == false {
+		t.Fatalf("extraScopes returned false with extra scopes")
+	}
+
 }

--- a/access_test.go
+++ b/access_test.go
@@ -193,3 +193,22 @@ func TestAccessClientCredentials(t *testing.T) {
 		t.Fatalf("Refresh token should not be generated: %s", d)
 	}
 }
+
+func TestExtraScopes(t *testing.T) {
+	if extraScopes("", "") == true {
+		t.Fatalf("extraScopes returned true with empty scopes")
+	}
+
+	if extraScopes("a", "") == true {
+		t.Fatalf("extraScopes returned true with less scopes")
+	}
+
+	if extraScopes("a,b", "b,a") == true {
+		t.Fatalf("extraScopes returned true with matching scopes")
+	}
+
+	if extraScopes("a,b", "b,a,c") == false {
+		t.Fatalf("extraScopes returned false with extra scopes")
+	}
+
+}


### PR DESCRIPTION
Hello! If I'm interpreting the rfc correctly, osin currently allows scopes to be elevated on a refresh in violation of: https://tools.ietf.org/html/rfc6749#section-6.

This patch makes sure that you can only ask for scopes that the the original access token had. I also included tests with coverage for the new function.
