### PR TITLE
Switch uuid to original implementation

### DIFF
--- a/tokengen.go
+++ b/tokengen.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"strings"
 
-	"github.com/satori/go.uuid"
+	"github.com/pborman/uuid"
 )
 
 // AuthorizeTokenGenDefault is the default authorization token generator
@@ -17,8 +17,8 @@ func removePadding(token string) string {
 
 // GenerateAuthorizeToken generates a base64-encoded UUID code
 func (a *AuthorizeTokenGenDefault) GenerateAuthorizeToken(data *AuthorizeData) (ret string, err error) {
-	token := uuid.NewV4()
-	return removePadding(base64.URLEncoding.EncodeToString(token.Bytes())), nil
+	token := uuid.NewRandom()
+	return removePadding(base64.URLEncoding.EncodeToString([]byte(token))), nil
 }
 
 // AccessTokenGenDefault is the default authorization token generator
@@ -27,12 +27,12 @@ type AccessTokenGenDefault struct {
 
 // GenerateAccessToken generates base64-encoded UUID access and refresh tokens
 func (a *AccessTokenGenDefault) GenerateAccessToken(data *AccessData, generaterefresh bool) (accesstoken string, refreshtoken string, err error) {
-	token := uuid.NewV4()
-	accesstoken = removePadding(base64.URLEncoding.EncodeToString(token.Bytes()))
+	token := uuid.NewRandom()
+	return removePadding(base64.URLEncoding.EncodeToString([]byte(token))), nil
 
 	if generaterefresh {
-		rtoken := uuid.NewV4()
-		refreshtoken = removePadding(base64.URLEncoding.EncodeToString(rtoken.Bytes()))
+		rtoken := uuid.NewRandom()
+		refreshtoken = removePadding(base64.URLEncoding.EncodeToString([]byte(rtoken)))
 	}
 	return
 }


### PR DESCRIPTION
The original uuid package (https://code.google.com/p/go-uuid/) has now been migrated to Github (https://github.com/pborman/uuid) by its author - a Googler and a Go language contributor (https://golang.org/CONTRIBUTORS#L478). It is a widely used package, including by Google projects like Kubernetes (https://godoc.org/code.google.com/p/go-uuid/uuid?importers).

As such, I think we should switch uuid back to its original implementation.

Additionally, the rationale for switching the implementation in #57 is no longer applicable - the repository has been moved to github.com, which is globally accessible.

Thank you for your time.