### PR TITLE
Match subpath correctly, prevent path traversals

### DIFF
--- a/urivalidate_test.go
+++ b/urivalidate_test.go
@@ -5,24 +5,95 @@ import (
 )
 
 func TestURIValidate(t *testing.T) {
-	// V1
-	if err := ValidateUri("http://localhost:14000/appauth", "http://localhost:14000/appauth"); err != nil {
-		t.Errorf("V1: %s", err)
+	valid := [][]string{
+		{
+			// Exact match
+			"http://localhost:14000/appauth",
+			"http://localhost:14000/appauth",
+		},
+		{
+			// Trailing slash
+			"http://www.google.com/myapp",
+			"http://www.google.com/myapp/",
+		},
+		{
+			// Exact match with trailing slash
+			"http://www.google.com/myapp/",
+			"http://www.google.com/myapp/",
+		},
+		{
+			// Subpath
+			"http://www.google.com/myapp",
+			"http://www.google.com/myapp/interface/implementation",
+		},
+		{
+			// Subpath with trailing slash
+			"http://www.google.com/myapp/",
+			"http://www.google.com/myapp/interface/implementation",
+		},
+		{
+			// Subpath with things that are close to path traversals, but aren't
+			"http://www.google.com/myapp",
+			"http://www.google.com/myapp/.../..implementation../...",
+		},
+		{
+			// If the allowed basepath contains path traversals, allow them?
+			"http://www.google.com/traversal/../allowed",
+			"http://www.google.com/traversal/../allowed/with/subpath",
+		},
+	}
+	for _, v := range valid {
+		if err := ValidateUri(v[0], v[1]); err != nil {
+			t.Errorf("Expected ValidateUri(%s, %s) to succeed, got %v", v[0], v[1], err)
+		}
 	}
 
-	// V2
-	if err := ValidateUri("http://localhost:14000/appauth", "http://localhost:14000/app"); err == nil {
-		t.Error("V2 should have failed")
+	invalid := [][]string{
+		{
+			// Doesn't satisfy base path
+			"http://localhost:14000/appauth",
+			"http://localhost:14000/app",
+		},
+		{
+			// Doesn't satisfy base path
+			"http://localhost:14000/app/",
+			"http://localhost:14000/app",
+		},
+		{
+			// Not a subpath of base path
+			"http://localhost:14000/appauth",
+			"http://localhost:14000/appauthmodifiedpath",
+		},
+		{
+			// Host mismatch
+			"http://www.google.com/myapp",
+			"http://www2.google.com/myapp",
+		},
+		{
+			// Scheme mismatch
+			"http://www.google.com/myapp",
+			"https://www.google.com/myapp",
+		},
+		{
+			// Path traversal
+			"http://www.google.com/myapp",
+			"http://www.google.com/myapp/..",
+		},
+		{
+			// Embedded path traversal
+			"http://www.google.com/myapp",
+			"http://www.google.com/myapp/../test",
+		},
+		{
+			// Not a subpath
+			"http://www.google.com/myapp",
+			"http://www.google.com/myapp../test",
+		},
 	}
-
-	// V3
-	if err := ValidateUri("http://www.google.com/myapp", "http://www.google.com/myapp/interface/implementation"); err != nil {
-		t.Errorf("V3: %s", err)
-	}
-
-	// V4
-	if err := ValidateUri("http://www.google.com/myapp", "http://www2.google.com/myapp"); err == nil {
-		t.Error("V4 should have failed")
+	for _, v := range invalid {
+		if err := ValidateUri(v[0], v[1]); err == nil {
+			t.Errorf("Expected ValidateUri(%s, %s) to fail", v[0], v[1])
+		}
 	}
 }
 


### PR DESCRIPTION
ValidateUri currently allows the following things:
* allows "http://foo.com/path-that-is-not-a-subpath" to match "http://foo.com/path", when only subpaths should be allowed
* allows "http://foo.com/path/with/../../../traversal" to match "http://foo.com/path", which effectively allows redirecting to paths outside the allowed redirect uri

This PR:
* Adds tests for those scenarios
* Prevents path traversal attacks
* Only allows prefix matching for true subpaths