### PR TITLE
Model the client secret as an interface

### DIFF
--- a/access.go
+++ b/access.go
@@ -510,7 +510,7 @@ func getClient(auth *BasicAuth, storage Storage, w *Response) Client {
 		w.SetError(E_UNAUTHORIZED_CLIENT, "")
 		return nil
 	}
-	if client.GetSecret() != auth.Password {
+	if !client.GetSecret().Validate(auth.Password) {
 		w.SetError(E_UNAUTHORIZED_CLIENT, "")
 		return nil
 	}

--- a/client.go
+++ b/client.go
@@ -6,7 +6,7 @@ type Client interface {
 	GetId() string
 
 	// Client secret
-	GetSecret() string
+	GetSecret() Secret
 
 	// Base client uri
 	GetRedirectUri() string
@@ -18,7 +18,7 @@ type Client interface {
 // DefaultClient stores all data in struct variables
 type DefaultClient struct {
 	Id          string
-	Secret      string
+	Secret      Secret
 	RedirectUri string
 	UserData    interface{}
 }
@@ -27,7 +27,7 @@ func (d *DefaultClient) GetId() string {
 	return d.Id
 }
 
-func (d *DefaultClient) GetSecret() string {
+func (d *DefaultClient) GetSecret() Secret {
 	return d.Secret
 }
 
@@ -44,4 +44,17 @@ func (d *DefaultClient) CopyFrom(client Client) {
 	d.Secret = client.GetSecret()
 	d.RedirectUri = client.GetRedirectUri()
 	d.UserData = client.GetUserData()
+}
+
+// Secret encapsulates information about a client secret.
+type Secret interface {
+	// Validate returns true if the given string matches the client secret.
+	Validate(string) bool
+}
+
+// DefaultSecret stores a client secret in cleartext.
+type DefaultSecret string
+
+func (d DefaultSecret) Validate(secret string) bool {
+	return secret == string(d)
 }


### PR DESCRIPTION
Osin's current architecture assumes that the client secret will always be available in cleartext, and that validation of the client secret will be accomplished by simple string comparison.  My project, however, required that we treat client secrets in the same way we would a user password — they must be salted and hashed before being stored in a database.

This pull request introduces the `Secret` interface type, which defines a `Validate(string) bool` method to validate the client secret specified in an OAuth request.  This interfaces enables consumers of the osin package to define customized methods of validating client credentials.  The old, cleartext-based method is preserved in the new `DefaultSecret` type.
