### PR TITLE
consts with custom types must have their types specified unless they undergo type conversion

### DIFF
--- a/access.go
+++ b/access.go
@@ -12,11 +12,11 @@ type AccessRequestType string
 
 const (
 	AUTHORIZATION_CODE AccessRequestType = "authorization_code"
-	REFRESH_TOKEN                        = "refresh_token"
-	PASSWORD                             = "password"
-	CLIENT_CREDENTIALS                   = "client_credentials"
-	ASSERTION                            = "assertion"
-	IMPLICIT                             = "__implicit"
+	REFRESH_TOKEN      AccessRequestType = "refresh_token"
+	PASSWORD           AccessRequestType = "password"
+	CLIENT_CREDENTIALS AccessRequestType = "client_credentials"
+	ASSERTION          AccessRequestType = "assertion"
+	IMPLICIT           AccessRequestType = "__implicit"
 )
 
 // AccessRequest is a request for access tokens

--- a/authorize.go
+++ b/authorize.go
@@ -11,7 +11,7 @@ type AuthorizeRequestType string
 
 const (
 	CODE  AuthorizeRequestType = "code"
-	TOKEN                      = "token"
+	TOKEN AuthorizeRequestType = "token"
 )
 
 // Authorize request information


### PR DESCRIPTION
It is a common misconception that declarations within a const block will all be created with the type of the first declared const. This only happens when there is an `iota` or other form of implicit type conversion.

The consts declared in `access.go` and `authorize.go` need their type specified or they will be declared as type `string`. As currently written:

```go
const (
	CODE  AuthorizeRequestType = "code"
	TOKEN                      = "token"
)
```
Calling `reflect.TypeOf(TOKEN)` will return `string`.

The consts in `response.go` do not need modification as they are subject to the implicit type conversion of `iota`.