### PR TITLE
Added storage section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Open in your web browser:
 http://localhost:14000/authorize?response_type=code&client_id=1234&redirect_uri=http%3A%2F%2Flocalhost%3A14000%2Fappauth%2Fcode
 ````
 
+### Storage backends
+
+There is a mock available at [/example/teststorage.go](/example/teststorage.go) which you can use as a guide for writing your own.  
+You might want to check out [`github.com/ory-am/osin-storage`](https://github.com/ory-am/osin-storage), which provides a PostgreSQL storage implementation for osin.
+
 ### License
 
 The code is licensed using "New BSD" license.


### PR DESCRIPTION
I've added a *storage backends* section where all available storage implementations could be linked. I'm also the author of [osin-storage](https://github.com/ory-am/osin-storage) in case you have questions regarding that.