### PR TITLE
For Defining New Response Types

### DIFF
--- a/authorize.go
+++ b/authorize.go
@@ -136,7 +136,8 @@ func (s *Server) HandleAuthorizeRequest(w *Response, r *http.Request) *Authorize
 
 	requestType := AuthorizeRequestType(r.Form.Get("response_type"))
 	if s.Config.AllowedAuthorizeTypes.Exists(requestType) {
-		switch requestType {
+		knownRequestType := GetKnownAuthorizeRequestType(requestType)
+		switch knownRequestType {
 		case CODE:
 			ret.Type = CODE
 			ret.Expiration = s.Config.AuthorizationExpiration

--- a/config.go
+++ b/config.go
@@ -6,7 +6,7 @@ type AllowedAuthorizeType []AuthorizeRequestType
 // Exists returns true if the auth type exists in the list
 func (t AllowedAuthorizeType) Exists(rt AuthorizeRequestType) bool {
 	for _, k := range t {
-		if k == rt {
+		if EqualAuthorizeRequestType(k, rt) {
 			return true
 		}
 	}

--- a/util.go
+++ b/util.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"net/http"
+	"reflect"
 	"strings"
 )
 
@@ -89,4 +90,31 @@ func getClientAuth(w *Response, r *http.Request, allowQueryParams bool) *BasicAu
 		return nil
 	}
 	return auth
+}
+
+func EqualAuthorizeRequestType(t1, t2 AuthorizeRequestType) bool {
+	t1s := strings.Split(string(t1), " ")
+	t2s := strings.Split(string(t2), " ")
+	return reflect.DeepEqual(t1s, t2s)
+}
+
+func GetKnownAuthorizeRequestType(rt AuthorizeRequestType) AuthorizeRequestType {
+	rts := strings.Split(string(rt), " ")
+	hasCode := false
+	hasToken := false
+	for _, v := range rts {
+		switch AuthorizeRequestType(v) {
+		case CODE:
+			hasCode = true
+		case TOKEN:
+			hasToken = true
+		}
+	}
+	if hasCode { // if both have, consider as code flow
+		return CODE
+	} else if hasToken {
+		return TOKEN
+	} else {
+		return ""
+	}
 }

--- a/util.go
+++ b/util.go
@@ -100,19 +100,16 @@ func EqualAuthorizeRequestType(t1, t2 AuthorizeRequestType) bool {
 
 func GetKnownAuthorizeRequestType(rt AuthorizeRequestType) AuthorizeRequestType {
 	rts := strings.Split(string(rt), " ")
-	hasCode := false
 	hasToken := false
 	for _, v := range rts {
 		switch AuthorizeRequestType(v) {
-		case CODE:
-			hasCode = true
+		case CODE: // if both of CODE and TOKEN exist, considered as code flow
+			return CODE
 		case TOKEN:
 			hasToken = true
 		}
 	}
-	if hasCode { // if both have, consider as code flow
-		return CODE
-	} else if hasToken {
+	if hasToken {
 		return TOKEN
 	} else {
 		return ""


### PR DESCRIPTION
According to http://tools.ietf.org/html/rfc6749#section-8.4, the response_type can be something else. But if I pass the http.request with another response_type, such as 'response_type = "token id_token"', I think osin should do what osin knows, i.e. handle the token request since other protocol like oidc is based on oauth2. 