### PR TITLE
Allow salted client secrets

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,6 +15,14 @@ type Client interface {
 	GetUserData() interface{}
 }
 
+// ClientSecretMatcher is an optional interface clients can implement
+// which allows them to be the one to determine if a secret matches.
+// If a Client implements ClientSecretMatcher, the framework will never call GetSecret
+type ClientSecretMatcher interface {
+	// SecretMatches returns true if the given secret matches
+	ClientSecretMatches(secret string) bool
+}
+
 // DefaultClient stores all data in struct variables
 type DefaultClient struct {
 	Id          string
@@ -37,6 +45,11 @@ func (d *DefaultClient) GetRedirectUri() string {
 
 func (d *DefaultClient) GetUserData() interface{} {
 	return d.UserData
+}
+
+// Implement the ClientSecretMatcher interface
+func (d *DefaultClient) ClientSecretMatches(secret string) bool {
+	return d.Secret == secret
 }
 
 func (d *DefaultClient) CopyFrom(client Client) {


### PR DESCRIPTION
This allows clients to implement an interface which gives them control over determining whether a secret matches. This enables encrypted/salted client secret storage, instead of assuming the original client secret can be extracted.

This is done as an optional interface and interface check to remain backwards-compatible with the existing `Client` interface.