### PR TITLE
Use authorization header token only if token type is bearer in CheckBearerAuth function..

### DIFF
--- a/util.go
+++ b/util.go
@@ -51,11 +51,11 @@ func CheckBearerAuth(r *http.Request) *BearerAuth {
 	token := authForm
 	if authHeader != "" {
 		s := strings.SplitN(authHeader, " ", 2)
-		if (len(s) != 2 || s[0] != "Bearer") && token == "" {
+		if (len(s) != 2 ||  strings.toLower(s[0]) != "bearer") && token == "" {
 			return nil
 		}
 		//Use authorization header token only if token type is bearer else query string access token would be returned
-		if(len(s)>0 && s[0]=="Bearer"){
+		if(len(s)>0 && strings.toLower(s[0])=="bearer"){
 			token = s[1]
 		}
 	}

--- a/util.go
+++ b/util.go
@@ -54,7 +54,10 @@ func CheckBearerAuth(r *http.Request) *BearerAuth {
 		if (len(s) != 2 || s[0] != "Bearer") && token == "" {
 			return nil
 		}
-		token = s[1]
+		//Use authorization header token only if token type is bearer else query string access token would be returned
+		if(len(s)>0 && s[0]=="Bearer"){
+			token = s[1]
+		}
 	}
 	return &BearerAuth{Code: token}
 }


### PR DESCRIPTION
We should use authorization header token only if token type is "Bearer" in CheckBearerAuth function. Currently even if we pass "Basic" token type, this function simply ignores the query string access token and return back the basic token. Because of this info API in complete example is failing.