### PR TITLE
fixed example/jwttoken/jwttoken.go compilation errors

### DIFF
--- a/example/jwttoken/jwttoken.go
+++ b/example/jwttoken/jwttoken.go
@@ -20,9 +20,10 @@ type AccessTokenGenJWT struct {
 
 func (c *AccessTokenGenJWT) GenerateAccessToken(data *osin.AccessData, generaterefresh bool) (accesstoken string, refreshtoken string, err error) {
 	// generate JWT access token
-	token := jwt.New(jwt.GetSigningMethod("RS256"))
-	token.Claims["cid"] = data.Client.GetId()
-	token.Claims["exp"] = data.ExpireAt().Unix()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"cid": data.Client.GetId(),
+		"exp": data.ExpireAt().Unix(),
+	})
 
 	accesstoken, err = token.SignedString(c.PrivateKey)
 	if err != nil {
@@ -34,10 +35,11 @@ func (c *AccessTokenGenJWT) GenerateAccessToken(data *osin.AccessData, generater
 	}
 
 	// generate JWT refresh token
-	token = jwt.New(jwt.GetSigningMethod("RS256"))
-	token.Claims["cid"] = data.Client.GetId()
-	token.Claims["at"] = accesstoken
-	token.Claims["exp"] = data.ExpireAt().Unix()
+	token = jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"cid": data.Client.GetId(),
+		"at":  accesstoken,
+		"exp": data.ExpireAt().Unix(),
+	})
 
 	refreshtoken, err = token.SignedString(c.PrivateKey)
 	if err != nil {


### PR DESCRIPTION
fixed example/jwttoken/jwttoken.go compilation errors following the jwt-go documentation:

Errors:
```
./jwttoken.go:24: invalid operation: token.Claims["cid"] (type jwt.Claims does not support indexing)
./jwttoken.go:25: invalid operation: token.Claims["exp"] (type jwt.Claims does not support indexing)
./jwttoken.go:38: invalid operation: token.Claims["cid"] (type jwt.Claims does not support indexing)
./jwttoken.go:39: invalid operation: token.Claims["at"] (type jwt.Claims does not support indexing)
./jwttoken.go:40: invalid operation: token.Claims["exp"] (type jwt.Claims does not support indexing)
```

Docs:
https://godoc.org/github.com/dgrijalva/jwt-go#example-Parse--Hmac
https://godoc.org/github.com/dgrijalva/jwt-go#example-New--Hmac