### PR TITLE
fixed typo that causes incorrect token signing method

### DIFF
--- a/example/jwttoken/jwttoken.go
+++ b/example/jwttoken/jwttoken.go
@@ -35,7 +35,7 @@ func (c *AccessTokenGenJWT) GenerateAccessToken(data *osin.AccessData, generater
 	}
 
 	// generate JWT refresh token
-	token = jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+	token = jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
 		"cid": data.Client.GetId(),
 		"at":  accesstoken,
 		"exp": data.ExpireAt().Unix(),


### PR DESCRIPTION
Refresh token was signed by HMAC instead of RSA