### PR TITLE
Replace custom removePadding with base64.NoPadding

### DIFF
--- a/tokengen.go
+++ b/tokengen.go
@@ -2,7 +2,6 @@ package osin
 
 import (
 	"encoding/base64"
-	"strings"
 
 	"github.com/pborman/uuid"
 )
@@ -11,14 +10,10 @@ import (
 type AuthorizeTokenGenDefault struct {
 }
 
-func removePadding(token string) string {
-	return strings.TrimRight(token, "=")
-}
-
 // GenerateAuthorizeToken generates a base64-encoded UUID code
 func (a *AuthorizeTokenGenDefault) GenerateAuthorizeToken(data *AuthorizeData) (ret string, err error) {
 	token := uuid.NewRandom()
-	return removePadding(base64.URLEncoding.EncodeToString([]byte(token))), nil
+	return base64.RawURLEncoding.EncodeToString([]byte(token)), nil
 }
 
 // AccessTokenGenDefault is the default authorization token generator
@@ -28,11 +23,11 @@ type AccessTokenGenDefault struct {
 // GenerateAccessToken generates base64-encoded UUID access and refresh tokens
 func (a *AccessTokenGenDefault) GenerateAccessToken(data *AccessData, generaterefresh bool) (accesstoken string, refreshtoken string, err error) {
 	token := uuid.NewRandom()
-	accesstoken = removePadding(base64.URLEncoding.EncodeToString([]byte(token)))
+	accesstoken = base64.RawURLEncoding.EncodeToString([]byte(token))
 
 	if generaterefresh {
 		rtoken := uuid.NewRandom()
-		refreshtoken = removePadding(base64.URLEncoding.EncodeToString([]byte(rtoken)))
+		refreshtoken = base64.RawURLEncoding.EncodeToString([]byte(rtoken))
 	}
 	return
 }


### PR DESCRIPTION
Base64 encoder officially provides an ability to avoid adding the padding characters.
Calling strings.TrimRight() would add overhead onto it, so we should just use WithPadding(base64.NoPadding) instead.