### PR TITLE
Add PKCE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Golang OAuth2 server library
 OSIN is an OAuth2 server library for the Go language, as specified at
 http://tools.ietf.org/html/rfc6749 and http://tools.ietf.org/html/draft-ietf-oauth-v2-10.
 
+It also includes support for PKCE, as specified at https://tools.ietf.org/html/rfc7636,
+which increases security for code-exchange flows for public OAuth clients.
+
 Using it, you can build your own OAuth2 authentication service.
 
 The library implements the majority of the specification, like authorization and token endpoints, and authorization code, implicit, resource owner and client credentials grant types.

--- a/access.go
+++ b/access.go
@@ -1,6 +1,8 @@
 package osin
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"net/http"
 	"strings"
@@ -50,6 +52,9 @@ type AccessRequest struct {
 
 	// HttpRequest *http.Request for special use
 	HttpRequest *http.Request
+
+	// Optional code_verifier as described in rfc7636
+	CodeVerifier string
 }
 
 // AccessData represents an access grant (tokens, expiration, client, etc)
@@ -158,6 +163,7 @@ func (s *Server) handleAuthorizationCodeRequest(w *Response, r *http.Request) *A
 	ret := &AccessRequest{
 		Type:            AUTHORIZATION_CODE,
 		Code:            r.Form.Get("code"),
+		CodeVerifier:    r.Form.Get("code_verifier"),
 		RedirectUri:     r.Form.Get("redirect_uri"),
 		GenerateRefresh: true,
 		Expiration:      s.Config.AccessExpiration,
@@ -219,6 +225,34 @@ func (s *Server) handleAuthorizationCodeRequest(w *Response, r *http.Request) *A
 		w.SetError(E_INVALID_REQUEST, "")
 		w.InternalError = errors.New("Redirect uri is different")
 		return nil
+	}
+
+	// Verify PKCE, if present in the authorization data
+	if len(ret.AuthorizeData.CodeChallenge) > 0 {
+		// https://tools.ietf.org/html/rfc7636#section-4.1
+		if matched := pkceMatcher.MatchString(ret.CodeVerifier); !matched {
+			w.SetError(E_INVALID_REQUEST, "code_verifier invalid (rfc7636)")
+			w.InternalError = errors.New("invalid format")
+			return nil
+		}
+
+		// https: //tools.ietf.org/html/rfc7636#section-4.6
+		codeVerifier := ""
+		switch ret.AuthorizeData.CodeChallengeMethod {
+		case "", PKCE_PLAIN:
+			codeVerifier = ret.CodeVerifier
+		case PKCE_S256:
+			hash := sha256.Sum256([]byte(ret.CodeVerifier))
+			codeVerifier = base64.RawURLEncoding.EncodeToString(hash[:])
+		default:
+			w.SetError(E_INVALID_REQUEST, "code_challenge_method transform algorithm not supported (rfc7636)")
+			return nil
+		}
+		if codeVerifier != ret.AuthorizeData.CodeChallenge {
+			w.SetError(E_INVALID_GRANT, "code_verifier invalid (rfc7636)")
+			w.InternalError = errors.New("failed comparison with code_challenge")
+			return nil
+		}
 	}
 
 	// set rest of data

--- a/access.go
+++ b/access.go
@@ -511,19 +511,9 @@ func getClient(auth *BasicAuth, storage Storage, w *Response) Client {
 		return nil
 	}
 
-	switch client := client.(type) {
-	case ClientSecretMatcher:
-		// Prefer the more secure method of giving the secret to the client for comparison
-		if !client.ClientSecretMatches(auth.Password) {
-			w.SetError(E_UNAUTHORIZED_CLIENT, "")
-			return nil
-		}
-	default:
-		// Fallback to the less secure method of extracting the plain text secret from the client for comparison
-		if client.GetSecret() != auth.Password {
-			w.SetError(E_UNAUTHORIZED_CLIENT, "")
-			return nil
-		}
+	if !CheckClientSecret(client, auth.Password) {
+		w.SetError(E_UNAUTHORIZED_CLIENT, "")
+		return nil
 	}
 
 	if client.GetRedirectUri() == "" {

--- a/authorize_test.go
+++ b/authorize_test.go
@@ -3,6 +3,7 @@ package osin
 import (
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -84,5 +85,173 @@ func TestAuthorizeToken(t *testing.T) {
 
 	if d := resp.Output["access_token"]; d != "1" {
 		t.Fatalf("Unexpected access token: %s", d)
+	}
+}
+
+func TestAuthorizeCodePKCERequired(t *testing.T) {
+	sconfig := NewServerConfig()
+	sconfig.RequirePKCEForPublicClients = true
+	sconfig.AllowedAuthorizeTypes = AllowedAuthorizeType{CODE}
+	server := NewServer(sconfig, NewTestingStorage())
+	server.AuthorizeTokenGen = &TestingAuthorizeTokenGen{}
+
+	// Public client returns an error
+	{
+		resp := server.NewResponse()
+		req, err := http.NewRequest("GET", "http://localhost:14000/appauth", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Form = make(url.Values)
+		req.Form.Set("response_type", string(CODE))
+		req.Form.Set("state", "a")
+		req.Form.Set("client_id", "public-client")
+		if ar := server.HandleAuthorizeRequest(resp, req); ar != nil {
+			ar.Authorized = true
+			server.FinishAuthorizeRequest(resp, req, ar)
+		}
+		if !resp.IsError || resp.ErrorId != "invalid_request" || strings.Contains(resp.StatusText, "code_challenge") {
+			t.Errorf("Expected invalid_request error describing the code_challenge required, got %#v", resp)
+		}
+	}
+
+	// Confidential client works without PKCE
+	{
+		resp := server.NewResponse()
+		req, err := http.NewRequest("GET", "http://localhost:14000/appauth", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Form = make(url.Values)
+		req.Form.Set("response_type", string(CODE))
+		req.Form.Set("state", "a")
+		req.Form.Set("client_id", "1234")
+		if ar := server.HandleAuthorizeRequest(resp, req); ar != nil {
+			ar.Authorized = true
+			server.FinishAuthorizeRequest(resp, req, ar)
+		}
+		if resp.IsError && resp.InternalError != nil {
+			t.Fatalf("Error in response: %s", resp.InternalError)
+		}
+		if resp.IsError {
+			t.Fatalf("Should not be an error")
+		}
+		if resp.Type != REDIRECT {
+			t.Fatalf("Response should be a redirect")
+		}
+		if d := resp.Output["code"]; d != "1" {
+			t.Fatalf("Unexpected authorization code: %s", d)
+		}
+	}
+}
+
+func TestAuthorizeCodePKCEPlain(t *testing.T) {
+	challenge := "12345678901234567890123456789012345678901234567890"
+
+	sconfig := NewServerConfig()
+	sconfig.AllowedAuthorizeTypes = AllowedAuthorizeType{CODE}
+	server := NewServer(sconfig, NewTestingStorage())
+	server.AuthorizeTokenGen = &TestingAuthorizeTokenGen{}
+	resp := server.NewResponse()
+
+	req, err := http.NewRequest("GET", "http://localhost:14000/appauth", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Form = make(url.Values)
+	req.Form.Set("response_type", string(CODE))
+	req.Form.Set("client_id", "1234")
+	req.Form.Set("state", "a")
+	req.Form.Set("code_challenge", challenge)
+
+	if ar := server.HandleAuthorizeRequest(resp, req); ar != nil {
+		ar.Authorized = true
+		server.FinishAuthorizeRequest(resp, req, ar)
+	}
+
+	//fmt.Printf("%+v", resp)
+
+	if resp.IsError && resp.InternalError != nil {
+		t.Fatalf("Error in response: %s", resp.InternalError)
+	}
+
+	if resp.IsError {
+		t.Fatalf("Should not be an error")
+	}
+
+	if resp.Type != REDIRECT {
+		t.Fatalf("Response should be a redirect")
+	}
+
+	code, ok := resp.Output["code"].(string)
+	if !ok || code != "1" {
+		t.Fatalf("Unexpected authorization code: %s", code)
+	}
+
+	token, err := server.Storage.LoadAuthorize(code)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if token.CodeChallenge != challenge {
+		t.Errorf("Expected stored code_challenge %s, got %s", challenge, token.CodeChallenge)
+	}
+	if token.CodeChallengeMethod != "plain" {
+		t.Errorf("Expected stored code_challenge plain, got %s", token.CodeChallengeMethod)
+	}
+}
+
+func TestAuthorizeCodePKCES256(t *testing.T) {
+	challenge := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+	sconfig := NewServerConfig()
+	sconfig.AllowedAuthorizeTypes = AllowedAuthorizeType{CODE}
+	server := NewServer(sconfig, NewTestingStorage())
+	server.AuthorizeTokenGen = &TestingAuthorizeTokenGen{}
+	resp := server.NewResponse()
+
+	req, err := http.NewRequest("GET", "http://localhost:14000/appauth", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Form = make(url.Values)
+	req.Form.Set("response_type", string(CODE))
+	req.Form.Set("client_id", "1234")
+	req.Form.Set("state", "a")
+	req.Form.Set("code_challenge", challenge)
+	req.Form.Set("code_challenge_method", "S256")
+
+	if ar := server.HandleAuthorizeRequest(resp, req); ar != nil {
+		ar.Authorized = true
+		server.FinishAuthorizeRequest(resp, req, ar)
+	}
+
+	//fmt.Printf("%+v", resp)
+
+	if resp.IsError && resp.InternalError != nil {
+		t.Fatalf("Error in response: %s", resp.InternalError)
+	}
+
+	if resp.IsError {
+		t.Fatalf("Should not be an error")
+	}
+
+	if resp.Type != REDIRECT {
+		t.Fatalf("Response should be a redirect")
+	}
+
+	code, ok := resp.Output["code"].(string)
+	if !ok || code != "1" {
+		t.Fatalf("Unexpected authorization code: %s", code)
+	}
+
+	token, err := server.Storage.LoadAuthorize(code)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if token.CodeChallenge != challenge {
+		t.Errorf("Expected stored code_challenge %s, got %s", challenge, token.CodeChallenge)
+	}
+	if token.CodeChallengeMethod != "S256" {
+		t.Errorf("Expected stored code_challenge S256, got %s", token.CodeChallengeMethod)
 	}
 }

--- a/config.go
+++ b/config.go
@@ -54,6 +54,9 @@ type ServerConfig struct {
 	// If true allows access request using GET, else only POST - default false
 	AllowGetAccessRequest bool
 
+	// Require PKCE for code flows for public OAuth clients - default false
+	RequirePKCEForPublicClients bool
+
 	// Separator to support multiple URIs in Client.GetRedirectUri().
 	// If blank (the default), don't allow multiple URIs.
 	RedirectUriSeparator string

--- a/storage_test.go
+++ b/storage_test.go
@@ -27,6 +27,11 @@ func NewTestingStorage() *TestingStorage {
 		RedirectUri: "http://localhost:14000/appauth",
 	}
 
+	r.clients["public-client"] = &DefaultClient{
+		Id:          "public-client",
+		RedirectUri: "http://localhost:14000/appauth",
+	}
+
 	r.authorize["9999"] = &AuthorizeData{
 		Client:      r.clients["1234"],
 		Code:        "9999",

--- a/util.go
+++ b/util.go
@@ -18,6 +18,19 @@ type BearerAuth struct {
 	Code string
 }
 
+// CheckClientSecret determines whether the given secret matches a secret held by the client.
+// Public clients return true for a secret of ""
+func CheckClientSecret(client Client, secret string) bool {
+	switch client := client.(type) {
+	case ClientSecretMatcher:
+		// Prefer the more secure method of giving the secret to the client for comparison
+		return client.ClientSecretMatches(secret)
+	default:
+		// Fallback to the less secure method of extracting the plain text secret from the client for comparison
+		return client.GetSecret() == secret
+	}
+}
+
 // Return authorization header data
 func CheckBasicAuth(r *http.Request) (*BasicAuth, error) {
 	if r.Header.Get("Authorization") == "" {
@@ -51,11 +64,11 @@ func CheckBearerAuth(r *http.Request) *BearerAuth {
 	token := authForm
 	if authHeader != "" {
 		s := strings.SplitN(authHeader, " ", 2)
-		if (len(s) != 2 ||  strings.ToLower(s[0]) != "bearer") && token == "" {
+		if (len(s) != 2 || strings.ToLower(s[0]) != "bearer") && token == "" {
 			return nil
 		}
 		//Use authorization header token only if token type is bearer else query string access token would be returned
-		if(len(s)>0 && strings.ToLower(s[0])=="bearer"){
+		if len(s) > 0 && strings.ToLower(s[0]) == "bearer" {
 			token = s[1]
 		}
 	}


### PR DESCRIPTION
This adds support for https://tools.ietf.org/html/rfc7636, which improves the security of `code` flows with public clients (clients whose client_secret is not protected, or is empty)

Optional parameters parsed/validated on authorization requests: code_challenge, code_challenge_method

Optional parameters parsed/validated on access requests: code_verifier

If the provided storage does not persist/retrieve the given code_challenge/code_challenge_method, then the access token request gracefully falls back to ignoring any provided code_verifier param (as described by the RFC)

A new option is specified in server config to require PKCE for clients which would accept a client_secret of "". The default is false for backwards compatibility.