### PR TITLE
Fix fragment encoding

### DIFF
--- a/response.go
+++ b/response.go
@@ -117,8 +117,16 @@ func (r *Response) GetRedirectUrl() (string, error) {
 		return "", err
 	}
 
+	var q url.Values
+	if r.RedirectInFragment {
+		// start with empty set for fragment
+		q = url.Values{}
+	} else {
+		// add parameters to existing query
+		q = u.Query()
+	}
+
 	// add parameters
-	q := u.Query()
 	for n, v := range r.Output {
 		q.Set(n, fmt.Sprint(v))
 	}
@@ -127,7 +135,6 @@ func (r *Response) GetRedirectUrl() (string, error) {
 	// Fragment should be encoded as application/x-www-form-urlencoded (%-escaped, spaces are represented as '+')
 	// The stdlib URL#String() doesn't make that easy to accomplish, so build this ourselves
 	if r.RedirectInFragment {
-		u.RawQuery = ""
 		u.Fragment = ""
 		redirectURI := u.String() + "#" + q.Encode()
 		return redirectURI, nil

--- a/response.go
+++ b/response.go
@@ -122,16 +122,20 @@ func (r *Response) GetRedirectUrl() (string, error) {
 	for n, v := range r.Output {
 		q.Set(n, fmt.Sprint(v))
 	}
+
+	// https://tools.ietf.org/html/rfc6749#section-4.2.2
+	// Fragment should be encoded as application/x-www-form-urlencoded (%-escaped, spaces are represented as '+')
+	// The stdlib URL#String() doesn't make that easy to accomplish, so build this ourselves
 	if r.RedirectInFragment {
 		u.RawQuery = ""
-		u.Fragment, err = url.QueryUnescape(q.Encode())
-		if err != nil {
-			return "", err
-		}
-	} else {
-		u.RawQuery = q.Encode()
+		u.Fragment = ""
+		redirectURI := u.String() + "#" + q.Encode()
+		return redirectURI, nil
 	}
 
+	// Otherwise, update the query and encode normally
+	u.RawQuery = q.Encode()
+	u.Fragment = ""
 	return u.String(), nil
 }
 

--- a/response_test.go
+++ b/response_test.go
@@ -18,18 +18,18 @@ func TestGetRedirectUrl(t *testing.T) {
 		ExpectedURL string
 	}{
 		"query": {
-			URL:         "https://foo.com/path",
+			URL:         "https://foo.com/path?abc=123",
 			Output:      ResponseData{"access_token": "12345", "state": state},
-			ExpectedURL: "https://foo.com/path?access_token=12345&state=%7B%22then%22%3A+%22%2Findex.html%3Fa%3D1%26b%3D%252B%23fragment%22%2C+%22nonce%22%3A+%22014f%3Abff9a07c%22%7D",
+			ExpectedURL: "https://foo.com/path?abc=123&access_token=12345&state=%7B%22then%22%3A+%22%2Findex.html%3Fa%3D1%26b%3D%252B%23fragment%22%2C+%22nonce%22%3A+%22014f%3Abff9a07c%22%7D",
 		},
 
 		// https://tools.ietf.org/html/rfc6749#section-4.2.2
 		// Fragment should be encoded as application/x-www-form-urlencoded (%-escaped, spaces are represented as '+')
 		"fragment": {
-			URL:                "https://foo.com/path",
+			URL:                "https://foo.com/path?abc=123",
 			Output:             ResponseData{"access_token": "12345", "state": state},
 			RedirectInFragment: true,
-			ExpectedURL:        "https://foo.com/path#access_token=12345&state=%7B%22then%22%3A+%22%2Findex.html%3Fa%3D1%26b%3D%252B%23fragment%22%2C+%22nonce%22%3A+%22014f%3Abff9a07c%22%7D",
+			ExpectedURL:        "https://foo.com/path?abc=123#access_token=12345&state=%7B%22then%22%3A+%22%2Findex.html%3Fa%3D1%26b%3D%252B%23fragment%22%2C+%22nonce%22%3A+%22014f%3Abff9a07c%22%7D",
 		},
 	}
 

--- a/response_test.go
+++ b/response_test.go
@@ -1,0 +1,74 @@
+package osin
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestGetRedirectUrl(t *testing.T) {
+	// Make sure we can round-trip state parameters containing special URL characters, both as a query param and in an encoded fragment
+	state := `{"then": "/index.html?a=1&b=%2B#fragment", "nonce": "014f:bff9a07c"}`
+
+	testcases := map[string]struct {
+		URL                string
+		Output             ResponseData
+		RedirectInFragment bool
+
+		ExpectedURL string
+	}{
+		"query": {
+			URL:         "https://foo.com/path",
+			Output:      ResponseData{"access_token": "12345", "state": state},
+			ExpectedURL: "https://foo.com/path?access_token=12345&state=%7B%22then%22%3A+%22%2Findex.html%3Fa%3D1%26b%3D%252B%23fragment%22%2C+%22nonce%22%3A+%22014f%3Abff9a07c%22%7D",
+		},
+
+		// https://tools.ietf.org/html/rfc6749#section-4.2.2
+		// Fragment should be encoded as application/x-www-form-urlencoded (%-escaped, spaces are represented as '+')
+		"fragment": {
+			URL:                "https://foo.com/path",
+			Output:             ResponseData{"access_token": "12345", "state": state},
+			RedirectInFragment: true,
+			ExpectedURL:        "https://foo.com/path#access_token=12345&state=%7B%22then%22%3A+%22%2Findex.html%3Fa%3D1%26b%3D%252B%23fragment%22%2C+%22nonce%22%3A+%22014f%3Abff9a07c%22%7D",
+		},
+	}
+
+	for k, tc := range testcases {
+		resp := &Response{
+			Type:               REDIRECT,
+			URL:                tc.URL,
+			Output:             tc.Output,
+			RedirectInFragment: tc.RedirectInFragment,
+		}
+		result, err := resp.GetRedirectUrl()
+		if err != nil {
+			t.Errorf("%s: %v", k, err)
+			continue
+		}
+		if result != tc.ExpectedURL {
+			t.Errorf("%s: expected\n\t%v, got\n\t%v", k, tc.ExpectedURL, result)
+			continue
+		}
+
+		var params url.Values
+		if tc.RedirectInFragment {
+			params, err = url.ParseQuery(strings.SplitN(result, "#", 2)[1])
+			if err != nil {
+				t.Errorf("%s: %v", k, err)
+				continue
+			}
+		} else {
+			parsedResult, err := url.Parse(result)
+			if err != nil {
+				t.Errorf("%s: %v", k, err)
+				continue
+			}
+			params = parsedResult.Query()
+		}
+
+		if params["state"][0] != state {
+			t.Errorf("%s: expected\n\t%v, got\n\t%v", k, state, params["state"][0])
+			continue
+		}
+	}
+}


### PR DESCRIPTION
In the OAuth spec (https://tools.ietf.org/html/rfc6749#section-4.2.2), the fragment component
of the redirection URI is supposed to be constructed using the application/x-www-form-urlencoded
format.

The golang stdlib does not make it easy to include values encoded that way in a URL fragment (it
messes with *some* %-escaped values), and the way osin was trying to work around that (encode
query params, then unescape, then assign to the url fragment, then let the url stringify the fragment)
led to some special characters in the state param not getting escaped correctly.

This PR simplifies the fragment-building to construct the URI with the encoded params directly, and
adds test cases for both the query and fragment cases.

Additionally, any pre-existing query parameters on the redirect_uri are supposed to be preserved in the redirect. They were being moved to the fragment in a redirect case, instead of remaining in the query string.