### PR TITLE
Adding the option to retain refresh/access token after successfully refreshing a token

### DIFF
--- a/access.go
+++ b/access.go
@@ -507,7 +507,7 @@ func (s *Server) FinishAccessRequest(w *Response, r *http.Request, ar *AccessReq
 		}
 
 		// remove previous access token
-		if ret.AccessData != nil {
+		if ret.AccessData != nil && !s.Config.RetainTokenAfterRefresh {
 			if ret.AccessData.RefreshToken != "" {
 				w.Storage.RemoveRefresh(ret.AccessData.RefreshToken)
 			}

--- a/access_test.go
+++ b/access_test.go
@@ -77,8 +77,62 @@ func TestAccessRefreshToken(t *testing.T) {
 		ar.Authorized = true
 		server.FinishAccessRequest(resp, req, ar)
 	}
-
 	//fmt.Printf("%+v", resp)
+
+	if _, err := server.Storage.LoadRefresh("r9999"); err == nil {
+		t.Fatalf("token was not deleted")
+	}
+
+	if resp.IsError && resp.InternalError != nil {
+		t.Fatalf("Error in response: %s", resp.InternalError)
+	}
+
+	if resp.IsError {
+		t.Fatalf("Should not be an error")
+	}
+
+	if resp.Type != DATA {
+		t.Fatalf("Response should be data")
+	}
+
+	if d := resp.Output["access_token"]; d != "1" {
+		t.Fatalf("Unexpected access token: %s", d)
+	}
+
+	if d := resp.Output["refresh_token"]; d != "r1" {
+		t.Fatalf("Unexpected refresh token: %s", d)
+	}
+}
+
+func TestAccessRefreshTokenSaveToken(t *testing.T) {
+	sconfig := NewServerConfig()
+	sconfig.AllowedAccessTypes = AllowedAccessType{REFRESH_TOKEN}
+	server := NewServer(sconfig, NewTestingStorage())
+	server.AccessTokenGen = &TestingAccessTokenGen{}
+	server.Config.RetainTokenAfterRefresh = true
+	resp := server.NewResponse()
+
+	req, err := http.NewRequest("POST", "http://localhost:14000/appauth", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.SetBasicAuth("1234", "aabbccdd")
+
+	req.Form = make(url.Values)
+	req.Form.Set("grant_type", string(REFRESH_TOKEN))
+	req.Form.Set("refresh_token", "r9999")
+	req.Form.Set("state", "a")
+	req.PostForm = make(url.Values)
+
+	if ar := server.HandleAccessRequest(resp, req); ar != nil {
+		ar.Authorized = true
+		server.FinishAccessRequest(resp, req, ar)
+	}
+	//fmt.Printf("%+v", resp)
+
+	if _, err := server.Storage.LoadRefresh("r9999"); err != nil {
+		t.Fatalf("token incorrectly deleted: %s", err.Error())
+	}
 
 	if resp.IsError && resp.InternalError != nil {
 		t.Fatalf("Error in response: %s", resp.InternalError)

--- a/config.go
+++ b/config.go
@@ -60,6 +60,10 @@ type ServerConfig struct {
 	// Separator to support multiple URIs in Client.GetRedirectUri().
 	// If blank (the default), don't allow multiple URIs.
 	RedirectUriSeparator string
+
+	// RetainTokenAfter Refresh allows the server to retain the access and
+	// refresh token for re-use - default false
+	RetainTokenAfterRefresh bool
 }
 
 // NewServerConfig returns a new ServerConfig with default configuration
@@ -73,5 +77,6 @@ func NewServerConfig() *ServerConfig {
 		ErrorStatusCode:           200,
 		AllowClientSecretInParams: false,
 		AllowGetAccessRequest:     false,
+		RetainTokenAfterRefresh:   false,
 	}
 }


### PR DESCRIPTION
This is to address a use case where a client might want to re-use their refresh token.

According to RFC 6749, Section 6:

> The authorization server MAY issue a new refresh token, in which case the client MUST discard the old refresh token and replace it with the new refresh token.  The authorization server MAY revoke the old refresh token after issuing a new refresh token to the client.  If a new refresh token is issued, the refresh token scope MUST be identical to that of the refresh token included by the client in the request. 

I considered the case where a refresh token refers back to an access token via the storage interface (such as the test storage implementation). In this case, If the access token has been removed, using LoadRefresh() will return an error. To solve this, when a new config variable RetainTokenAfterRefresh is set, FinishAccessRequest() must skip removing both the access and refresh tokens.

Please let me know if you'd like me to make any tweaks!
