### PR TITLE
Example Server should call NewTestStorage in order to seed storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ The library implements the majority of the specification, like authorization and
 ### Example Server
 
 ````go
-import "github.com/RangelReale/osin"
+import (
+	"github.com/RangelReale/osin"
+	ex "github.com/RangelReale/osin/example" 
+)
 
-// TestStorage implements the "osin.Storage" interface
-server := osin.NewServer(osin.NewServerConfig(), &TestStorage{})
+// ex.NewTestStorage implements the "osin.Storage" interface
+server := osin.NewServer(osin.NewServerConfig(), ex.NewTestStorage())
 
 // Authorization code endpoint
 http.HandleFunc("/authorize", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The TestStorage device used by the "Example Server" isn't properly initialized with the default OAuth client-id of 1234.  This results in the message: E_SERVER_ERROR = "_The authorization server encountered an unexpected condition that prevented it from fulfilling the request._" when executing the example using the provided link:
```
http://localhost:14000/authorize?response_type=code&client_id=1234&redirect_uri=http%3A%2F%2Flocalhost%3A14000%2Fappauth%2Fcode
```

Updated example code to call _NewTestStorage_ function to properly initialize the TestStorage driver with the information for client-id "1234".
