### PR TITLE
Add ErrNotFound to Storage interface

### DIFF
--- a/example/teststorage.go
+++ b/example/teststorage.go
@@ -1,7 +1,6 @@
 package example
 
 import (
-	"errors"
 	"fmt"
 	"github.com/RangelReale/osin"
 )
@@ -42,7 +41,7 @@ func (s *TestStorage) GetClient(id string) (osin.Client, error) {
 	if c, ok := s.clients[id]; ok {
 		return c, nil
 	}
-	return nil, errors.New("Client not found")
+	return nil, osin.ErrNotFound
 }
 
 func (s *TestStorage) SetClient(id string, client osin.Client) error {
@@ -62,7 +61,7 @@ func (s *TestStorage) LoadAuthorize(code string) (*osin.AuthorizeData, error) {
 	if d, ok := s.authorize[code]; ok {
 		return d, nil
 	}
-	return nil, errors.New("Authorize not found")
+	return nil, osin.ErrNotFound
 }
 
 func (s *TestStorage) RemoveAuthorize(code string) error {
@@ -85,7 +84,7 @@ func (s *TestStorage) LoadAccess(code string) (*osin.AccessData, error) {
 	if d, ok := s.access[code]; ok {
 		return d, nil
 	}
-	return nil, errors.New("Access not found")
+	return nil, osin.ErrNotFound
 }
 
 func (s *TestStorage) RemoveAccess(code string) error {
@@ -99,7 +98,7 @@ func (s *TestStorage) LoadRefresh(code string) (*osin.AccessData, error) {
 	if d, ok := s.refresh[code]; ok {
 		return s.LoadAccess(d)
 	}
-	return nil, errors.New("Refresh not found")
+	return nil, osin.ErrNotFound
 }
 
 func (s *TestStorage) RemoveRefresh(code string) error {

--- a/storage.go
+++ b/storage.go
@@ -1,6 +1,16 @@
 package osin
 
-import ()
+import (
+	"errors"
+)
+
+var (
+	// ErrNotFound is the error returned by Storage Get<...> and Load<...> functions in case
+	// no entity is found in the storage. E.g. Storage.GetClient() returns ErrNotFound when
+	// client is not found. All other returned errors must be treated as storage-specific errors,
+	// like "connection lost", "connection refused", etc.
+	ErrNotFound = errors.New("Entity not found")
+)
 
 // Storage interface
 type Storage interface {

--- a/storage_test.go
+++ b/storage_test.go
@@ -1,7 +1,6 @@
 package osin
 
 import (
-	"errors"
 	"strconv"
 	"time"
 )
@@ -74,7 +73,7 @@ func (s *TestingStorage) GetClient(id string) (Client, error) {
 	if c, ok := s.clients[id]; ok {
 		return c, nil
 	}
-	return nil, errors.New("Client not found")
+	return nil, ErrNotFound
 }
 
 func (s *TestingStorage) SetClient(id string, client Client) error {
@@ -91,7 +90,7 @@ func (s *TestingStorage) LoadAuthorize(code string) (*AuthorizeData, error) {
 	if d, ok := s.authorize[code]; ok {
 		return d, nil
 	}
-	return nil, errors.New("Authorize not found")
+	return nil, ErrNotFound
 }
 
 func (s *TestingStorage) RemoveAuthorize(code string) error {
@@ -111,7 +110,7 @@ func (s *TestingStorage) LoadAccess(code string) (*AccessData, error) {
 	if d, ok := s.access[code]; ok {
 		return d, nil
 	}
-	return nil, errors.New("Access not found")
+	return nil, ErrNotFound
 }
 
 func (s *TestingStorage) RemoveAccess(code string) error {
@@ -123,7 +122,7 @@ func (s *TestingStorage) LoadRefresh(code string) (*AccessData, error) {
 	if d, ok := s.refresh[code]; ok {
 		return s.LoadAccess(d)
 	}
-	return nil, errors.New("Refresh not found")
+	return nil, ErrNotFound
 }
 
 func (s *TestingStorage) RemoveRefresh(code string) error {


### PR DESCRIPTION
The idea is to make `ErrNotFound` part of `Storage` interface, to have simple and clear way to distinguish storage-specific errors (driver errors) from logic errors and process errors in different ways. In my case it is about to return `500` HTTP Code in case of storage-specific error, and `400` or `404` when client or token is not found.

If this PR will be accepted I'll fix postgres implementation to use it (as I use it for my current project) and will see how easy it will be to fix other implementations.