### PR TITLE
fix: use AccessData scope instead of AccessRequest scope

### DIFF
--- a/access.go
+++ b/access.go
@@ -521,8 +521,8 @@ func (s *Server) FinishAccessRequest(w *Response, r *http.Request, ar *AccessReq
 		if ret.RefreshToken != "" {
 			w.Output["refresh_token"] = ret.RefreshToken
 		}
-		if ar.Scope != "" {
-			w.Output["scope"] = ar.Scope
+		if ret.Scope != "" {
+			w.Output["scope"] = ret.Scope
 		}
 	} else {
 		w.SetError(E_ACCESS_DENIED, "")


### PR DESCRIPTION
In order to be able to modify the scopes list in Storage.SaveAccess, in case of the client tried to get unauthorized scopes.
In the rfc6749#section-3.3: "If the issued access token scope is different from the one requested by the client, the authorization server MUST include the "scope" response parameter to inform the client of the actual scope granted."