### PR TITLE
Changing GET params to FormValue

### DIFF
--- a/access.go
+++ b/access.go
@@ -129,7 +129,7 @@ func (s *Server) HandleAccessRequest(w *Response, r *http.Request) *AccessReques
 		return nil
 	}
 
-	grantType := AccessRequestType(r.Form.Get("grant_type"))
+	grantType := AccessRequestType(r.FormValue("grant_type"))
 	if s.Config.AllowedAccessTypes.Exists(grantType) {
 		switch grantType {
 		case AUTHORIZATION_CODE:

--- a/access.go
+++ b/access.go
@@ -159,9 +159,9 @@ func (s *Server) handleAuthorizationCodeRequest(w *Response, r *http.Request) *A
 	// generate access token
 	ret := &AccessRequest{
 		Type:            AUTHORIZATION_CODE,
-		Code:            r.Form.Get("code"),
-		CodeVerifier:    r.Form.Get("code_verifier"),
-		RedirectUri:     r.Form.Get("redirect_uri"),
+		Code:            r.FormValue("code"),
+		CodeVerifier:    r.FormValue("code_verifier"),
+		RedirectUri:     r.FormValue("redirect_uri"),
 		GenerateRefresh: true,
 		Expiration:      s.Config.AccessExpiration,
 		HttpRequest:     r,
@@ -291,8 +291,8 @@ func (s *Server) handleRefreshTokenRequest(w *Response, r *http.Request) *Access
 	// generate access token
 	ret := &AccessRequest{
 		Type:            REFRESH_TOKEN,
-		Code:            r.Form.Get("refresh_token"),
-		Scope:           r.Form.Get("scope"),
+		Code:            r.FormValue("refresh_token"),
+		Scope:           r.FormValue("scope"),
 		GenerateRefresh: true,
 		Expiration:      s.Config.AccessExpiration,
 		HttpRequest:     r,
@@ -362,9 +362,9 @@ func (s *Server) handlePasswordRequest(w *Response, r *http.Request) *AccessRequ
 	// generate access token
 	ret := &AccessRequest{
 		Type:            PASSWORD,
-		Username:        r.Form.Get("username"),
-		Password:        r.Form.Get("password"),
-		Scope:           r.Form.Get("scope"),
+		Username:        r.FormValue("username"),
+		Password:        r.FormValue("password"),
+		Scope:           r.FormValue("scope"),
 		GenerateRefresh: true,
 		Expiration:      s.Config.AccessExpiration,
 		HttpRequest:     r,
@@ -397,7 +397,7 @@ func (s *Server) handleClientCredentialsRequest(w *Response, r *http.Request) *A
 	// generate access token
 	ret := &AccessRequest{
 		Type:            CLIENT_CREDENTIALS,
-		Scope:           r.Form.Get("scope"),
+		Scope:           r.FormValue("scope"),
 		GenerateRefresh: false,
 		Expiration:      s.Config.AccessExpiration,
 		HttpRequest:     r,
@@ -424,9 +424,9 @@ func (s *Server) handleAssertionRequest(w *Response, r *http.Request) *AccessReq
 	// generate access token
 	ret := &AccessRequest{
 		Type:            ASSERTION,
-		Scope:           r.Form.Get("scope"),
-		AssertionType:   r.Form.Get("assertion_type"),
-		Assertion:       r.Form.Get("assertion"),
+		Scope:           r.FormValue("scope"),
+		AssertionType:   r.FormValue("assertion_type"),
+		Assertion:       r.FormValue("assertion"),
 		GenerateRefresh: false, // assertion should NOT generate a refresh token, per the RFC
 		Expiration:      s.Config.AccessExpiration,
 		HttpRequest:     r,
@@ -454,7 +454,7 @@ func (s *Server) FinishAccessRequest(w *Response, r *http.Request, ar *AccessReq
 	if w.IsError {
 		return
 	}
-	redirectUri := r.Form.Get("redirect_uri")
+	redirectUri := r.FormValue("redirect_uri")
 	// Get redirect uri from AccessRequest if it's there (e.g., refresh token request)
 	if ar.RedirectUri != "" {
 		redirectUri = ar.RedirectUri

--- a/example/complete/complete.go
+++ b/example/complete/complete.go
@@ -103,7 +103,7 @@ func main() {
 	http.HandleFunc("/appauth/code", func(w http.ResponseWriter, r *http.Request) {
 		r.ParseForm()
 
-		code := r.Form.Get("code")
+		code := r.FormValue("code")
 
 		w.Write([]byte("<html><body>"))
 		w.Write([]byte("APP AUTH - CODE<br/>"))
@@ -121,7 +121,7 @@ func main() {
 			url.QueryEscape("http://localhost:14000/appauth/code"), url.QueryEscape(code))
 
 		// if parse, download and parse json
-		if r.Form.Get("doparse") == "1" {
+		if r.FormValue("doparse") == "1" {
 			err := example.DownloadAccessToken(fmt.Sprintf("http://localhost:14000%s", aurl),
 				&osin.BasicAuth{"1234", "aabbccdd"}, jr)
 			if err != nil {
@@ -318,7 +318,7 @@ func main() {
 		w.Write([]byte("APP AUTH - REFRESH<br/>"))
 		defer w.Write([]byte("</body></html>"))
 
-		code := r.Form.Get("code")
+		code := r.FormValue("code")
 
 		if code == "" {
 			w.Write([]byte("Nothing to do"))
@@ -369,7 +369,7 @@ func main() {
 		w.Write([]byte("APP AUTH - INFO<br/>"))
 		defer w.Write([]byte("</body></html>"))
 
-		code := r.Form.Get("code")
+		code := r.FormValue("code")
 
 		if code == "" {
 			w.Write([]byte("Nothing to do"))

--- a/example/goauth2client/goauth2client.go
+++ b/example/goauth2client/goauth2client.go
@@ -86,7 +86,7 @@ func main() {
 	http.HandleFunc("/appauth/code", func(w http.ResponseWriter, r *http.Request) {
 		r.ParseForm()
 
-		code := r.Form.Get("code")
+		code := r.FormValue("code")
 
 		w.Write([]byte("<html><body>"))
 		w.Write([]byte("APP AUTH - CODE<br/>"))
@@ -101,7 +101,7 @@ func main() {
 		var err error
 
 		// if parse, download and parse json
-		if r.Form.Get("doparse") == "1" {
+		if r.FormValue("doparse") == "1" {
 			jr, err = client.Exchange(oauth2.NoContext, code)
 			if err != nil {
 				jr = nil

--- a/example/helper.go
+++ b/example/helper.go
@@ -11,7 +11,7 @@ import (
 
 func HandleLoginPage(ar *osin.AuthorizeRequest, w http.ResponseWriter, r *http.Request) bool {
 	r.ParseForm()
-	if r.Method == "POST" && r.Form.Get("login") == "test" && r.Form.Get("password") == "test" {
+	if r.Method == "POST" && r.FormValue("login") == "test" && r.FormValue("password") == "test" {
 		return true
 	}
 

--- a/example/jwttoken/jwttoken.go
+++ b/example/jwttoken/jwttoken.go
@@ -122,7 +122,7 @@ func main() {
 	http.HandleFunc("/appauth/code", func(w http.ResponseWriter, r *http.Request) {
 		r.ParseForm()
 
-		code := r.Form.Get("code")
+		code := r.FormValue("code")
 
 		w.Write([]byte("<html><body>"))
 		w.Write([]byte("APP AUTH - CODE<br/>"))
@@ -140,7 +140,7 @@ func main() {
 			url.QueryEscape("http://localhost:14000/appauth/code"), url.QueryEscape(code))
 
 		// if parse, download and parse json
-		if r.Form.Get("doparse") == "1" {
+		if r.FormValue("doparse") == "1" {
 			err := example.DownloadAccessToken(fmt.Sprintf("http://localhost:14000%s", aurl),
 				&osin.BasicAuth{"1234", "aabbccdd"}, jr)
 			if err != nil {

--- a/example/simple/simple.go
+++ b/example/simple/simple.go
@@ -73,7 +73,7 @@ func main() {
 	http.HandleFunc("/appauth/code", func(w http.ResponseWriter, r *http.Request) {
 		r.ParseForm()
 
-		code := r.Form.Get("code")
+		code := r.FormValue("code")
 
 		w.Write([]byte("<html><body>"))
 		w.Write([]byte("APP AUTH - CODE<br/>"))
@@ -91,7 +91,7 @@ func main() {
 			url.QueryEscape("http://localhost:14000/appauth/code"), url.QueryEscape(code))
 
 		// if parse, download and parse json
-		if r.Form.Get("doparse") == "1" {
+		if r.FormValue("doparse") == "1" {
 			err := example.DownloadAccessToken(fmt.Sprintf("http://localhost:14000%s", aurl),
 				&osin.BasicAuth{"1234", "aabbccdd"}, jr)
 			if err != nil {

--- a/util.go
+++ b/util.go
@@ -71,7 +71,7 @@ func CheckBasicAuth(r *http.Request) (*BasicAuth, error) {
 // Return "Bearer" token from request. The header has precedence over query string.
 func CheckBearerAuth(r *http.Request) *BearerAuth {
 	authHeader := r.Header.Get("Authorization")
-	authForm := r.Form.Get("code")
+	authForm := r.FormValue("code")
 	if authHeader == "" && authForm == "" {
 		return nil
 	}
@@ -98,8 +98,8 @@ func (s Server) getClientAuth(w *Response, r *http.Request, allowQueryParams boo
 		// Allow for auth without password
 		if _, hasSecret := r.Form["client_secret"]; hasSecret {
 			auth := &BasicAuth{
-				Username: r.Form.Get("client_id"),
-				Password: r.Form.Get("client_secret"),
+				Username: r.FormValue("client_id"),
+				Password: r.FormValue("client_secret"),
 			}
 			if auth.Username != "" {
 				return auth


### PR DESCRIPTION
This will let someone add the params to the request body in a form with the Content-Type of:
```
Content-Type: application/x-www-form-urlencoded
``` 
This allows users to not have client_id and secret as well as username/password in the GET params.

In order to use it like this you must add the header:

```
Authorization: Basic base64_encode(client_id:client_secret)
```

Where base64_encode(client_id:client_secret) is an encoded string of client_id:client_secret